### PR TITLE
Move to arduino ide 1.6.4

### DIFF
--- a/EthernetBonjour.cpp
+++ b/EthernetBonjour.cpp
@@ -27,6 +27,9 @@
 #include <Ethernet.h>
 #include <EthernetUdp.h>
 
+#include "utility/w5100.h"
+#include "utility/socket.h"
+
 extern "C" {
    #include <utility/EthernetUtil.h>
 }

--- a/EthernetBonjour.h
+++ b/EthernetBonjour.h
@@ -121,6 +121,8 @@ public:
    
    int begin();
    int begin(const char* bonjourName);
+   uint8_t beginMulti(IPAddress ip, uint16_t port);
+   
    void run();
    
    int setBonjourName(const char* bonjourName);

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ mDNS (registering services) and DNS-SD (service discovery) has been tested and w
 Teensy++2 with WIZ81MJ and
 Teensy3 with WIZ820io
 
-Using Arduino 1.0.5 and Teensyduino 1.18
+Using Arduino 1.6.4 and Teensyduino 1.18, Mega Pro
 
 The newest revised code replaces all direct hardware calls to the W5100 chip with calls to EthernetUDP methods.
 This will provide much better adaptability to different Ethernet hardware. 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ EthernetBonjour
 Bonjour (ZeroConf) Library for Arduino & Teensyduino
 
 mDNS (registering services) and DNS-SD (service discovery) has been tested and works on:
-Teensy++2 with WIZ81MJ and
-Teensy3 with WIZ820io
+Teensy++2 with WIZ81MJ, Teensy3 with WIZ820io and Sparkfun Mega Pro
 
 Using Arduino 1.6.4 and Teensyduino 1.18, Mega Pro
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ EthernetBonjour
 Bonjour (ZeroConf) Library for Arduino & Teensyduino
 
 mDNS (registering services) and DNS-SD (service discovery) has been tested and works on:
-Teensy++2 with WIZ81MJ, Teensy3 with WIZ820io and Sparkfun Mega Pro
+Mega Pro and Ethernet Shield
 
-Using Arduino 1.6.4 and Teensyduino 1.18, Mega Pro
+Using Arduino 1.6.4 and Sparkfun Mega Pro
 
 The newest revised code replaces all direct hardware calls to the W5100 chip with calls to EthernetUDP methods.
 This will provide much better adaptability to different Ethernet hardware. 


### PR DESCRIPTION
This is an implementation of issue https://github.com/TrippyLighting/EthernetBonjour/issues/2

The only modification to `EthernetUDP.h` is to declare `_sock` as `protected`, not `private`.
All other projects that use EthernetUDP will continue to work (not the case with the friend class)

This pull-request does make direct calls to W5100 in EthernetBonjour.cpp (otherwise placed in EthernetUDP.cpp as per suggested fix in http://forum.arduino.cc/index.php?topic=234340.0)

This implementation has been tested on Mega Pro with Ethernet Shield (not Teensy).